### PR TITLE
Use dependencies2

### DIFF
--- a/.github/workflows/PackageValidation.yml
+++ b/.github/workflows/PackageValidation.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch ${{ vars.TOOLPATH }}
       - name: Verify Format
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch ${{ vars.TOOLPATH }}
       - name: Run Linter
@@ -36,8 +36,8 @@ jobs:
     runs-on: ${{ vars.RUNNER }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Xcode Version
         run: sudo xcode-select --switch ${{ vars.TOOLPATH }}
       - name: Build and Test
-        run: xcodebuild test -scheme ${{ github.event.repository.name }} -destination '${{ matrix.platforms.destination }}'
+        run: xcodebuild test -scheme ${{ github.event.repository.name }} -destination '${{ matrix.platforms.destination }}' -skipMacroValidation

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/FileSystemDependency.git",
       "state" : {
-        "revision" : "d3d09407f555ce497d8fbbbd43defb5e0491d48f",
-        "version" : "0.0.4"
+        "branch" : "UseDependencies2",
+        "revision" : "b882b3a322f3c8c8b5a79f93be6e4d90baf110b3"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/GlobalDependencies",
       "state" : {
-        "revision" : "dca8fb31eb9d6efc42b454aa4a5ea812d7d74c23",
-        "version" : "2.0.0"
+        "branch" : "MacroSupport",
+        "revision" : "5c459470b5df29f5ece204c828eeb7507b366e47"
       }
     },
     {
@@ -23,8 +23,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/NetworkDependency.git",
       "state" : {
-        "revision" : "3d9b7c28594f118b0b61d07842e161c06b8ba906",
-        "version" : "2.0.0"
+        "branch" : "UseDependencies2",
+        "revision" : "24e026327da95adc86a6c11f0472a1c3ad0d6bf7"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/FileSystemDependency.git",
       "state" : {
-        "branch" : "UseDependencies2",
-        "revision" : "4217b572c5a6bbde49770a702e4fe9fa884e89b7"
+        "revision" : "47f6e3b71bc698457538e9e513dcd9a37408ec96",
+        "version" : "1.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/GlobalDependencies",
       "state" : {
-        "branch" : "MacroSupport",
-        "revision" : "a18d6e6198fce826e2c0f0ad4998c8f0b07b3945"
+        "revision" : "088429933d5fc52a42f6f7bd820ae7e6c3d79981",
+        "version" : "2.0.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Gabardone/NetworkDependency.git",
       "state" : {
-        "branch" : "UseDependencies2",
-        "revision" : "cf6cbc99f440728b4890e92f0df424ce7d382d01"
+        "revision" : "63188a6884d5247c1ad07bdc9d49463745b16581",
+        "version" : "4.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/Gabardone/FileSystemDependency.git",
       "state" : {
         "branch" : "UseDependencies2",
-        "revision" : "b882b3a322f3c8c8b5a79f93be6e4d90baf110b3"
+        "revision" : "4217b572c5a6bbde49770a702e4fe9fa884e89b7"
       }
     },
     {
@@ -15,7 +15,7 @@
       "location" : "https://github.com/Gabardone/GlobalDependencies",
       "state" : {
         "branch" : "MacroSupport",
-        "revision" : "5c459470b5df29f5ece204c828eeb7507b366e47"
+        "revision" : "a18d6e6198fce826e2c0f0ad4998c8f0b07b3945"
       }
     },
     {
@@ -24,7 +24,7 @@
       "location" : "https://github.com/Gabardone/NetworkDependency.git",
       "state" : {
         "branch" : "UseDependencies2",
-        "revision" : "24e026327da95adc86a6c11f0472a1c3ad0d6bf7"
+        "revision" : "cf6cbc99f440728b4890e92f0df424ce7d382d01"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Gabardone/FileSystemDependency.git", from: "0.0.4"),
-        .package(url: "https://github.com/Gabardone/NetworkDependency.git", from: "2.0.0")
+        .package(url: "https://github.com/Gabardone/FileSystemDependency.git", branch: "UseDependencies2"),
+        .package(url: "https://github.com/Gabardone/NetworkDependency.git", branch: "UseDependencies2")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -20,8 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Gabardone/FileSystemDependency.git", branch: "UseDependencies2"),
-        .package(url: "https://github.com/Gabardone/NetworkDependency.git", branch: "UseDependencies2")
+        .package(url: "https://github.com/Gabardone/FileSystemDependency.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/Gabardone/NetworkDependency.git", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [
         .target(

--- a/Sources/SwiftCache/ValueSource/NetworkDataSource.swift
+++ b/Sources/SwiftCache/ValueSource/NetworkDataSource.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_exported import GlobalDependencies
 @_exported import NetworkDependency
 import os
 

--- a/Sources/SwiftCache/ValueStorage/LocalFileDataStorage.swift
+++ b/Sources/SwiftCache/ValueStorage/LocalFileDataStorage.swift
@@ -5,8 +5,9 @@
 //  Created by Óscar Morales Vivó on 4/23/23.
 //
 
-import FileSystemDependency
+@_exported import FileSystemDependency
 import Foundation
+@_exported import GlobalDependencies
 
 /**
  A simple implementation of local file system storage for caching.

--- a/Tests/SwiftCacheTests/CacheChainTests.swift
+++ b/Tests/SwiftCacheTests/CacheChainTests.swift
@@ -8,6 +8,11 @@
 import SwiftCache
 import XCTest
 
+#if os(macOS)
+// Shuts up the `Sendable` warnings in the tests.
+extension NSImage: @unchecked Sendable {}
+#endif
+
 extension CacheChainTests {
     #if os(macOS)
     typealias XXImage = NSImage

--- a/Tests/SwiftCacheTests/CacheChainTests.swift
+++ b/Tests/SwiftCacheTests/CacheChainTests.swift
@@ -8,77 +8,6 @@
 import SwiftCache
 import XCTest
 
-#if os(macOS)
-// Shuts up the `Sendable` warnings in the tests.
-extension NSImage: @unchecked Sendable {}
-#endif
-
-extension CacheChainTests {
-    #if os(macOS)
-    typealias XXImage = NSImage
-
-    private static let sampleImage: NSImage = {
-        let imageSize = CGSize(width: 256.0, height: 256.0)
-        return NSImage(size: imageSize, flipped: false) { rect in
-            NSColor.yellow.setFill()
-            NSBezierPath.fill(rect)
-            NSColor.blue.setFill()
-            NSBezierPath(ovalIn: .init(
-                x: imageSize.width / 8.0,
-                y: imageSize.height / 8.0,
-                width: imageSize.width / 4.0,
-                height: imageSize.height / 4.0
-            )
-            ).fill()
-            NSBezierPath(ovalIn: .init(
-                x: (imageSize.width * 5.0) / 8.0,
-                y: (imageSize.height * 5.0) / 8.0,
-                width: imageSize.width / 4.0,
-                height: imageSize.height / 4.0
-            )
-            ).fill()
-
-            return true
-        }
-    }()
-
-    private static let sampleImageData: Data = sampleImage.tiffRepresentation!
-    #else
-    typealias XXImage = UIImage
-
-    private static let sampleImage: UIImage = {
-        let imageSize = CGSize(width: 256.0, height: 256.0)
-        UIGraphicsBeginImageContext(imageSize)
-        defer {
-            UIGraphicsEndImageContext()
-        }
-
-        let context = UIGraphicsGetCurrentContext()!
-        UIColor.yellow.setFill()
-        context.fill(.init(origin: .zero, size: imageSize))
-        UIColor.blue.setFill()
-        UIBezierPath(ovalIn: .init(
-            x: imageSize.width / 8.0,
-            y: imageSize.height / 8.0,
-            width: imageSize.width / 4.0,
-            height: imageSize.height / 4.0
-        )
-        ).fill()
-        UIBezierPath(ovalIn: .init(
-            x: (imageSize.width * 5.0) / 8.0,
-            y: (imageSize.height * 5.0) / 8.0,
-            width: imageSize.width / 4.0,
-            height: imageSize.height / 4.0
-        )
-        ).fill()
-
-        return UIGraphicsGetImageFromCurrentImageContext()!
-    }()
-
-    private static let sampleImageData: Data = sampleImage.pngData()!
-    #endif
-}
-
 final class CacheChainTests: XCTestCase {
     private static let badImageData = Data(count: 16)
 
@@ -148,8 +77,8 @@ final class CacheChainTests: XCTestCase {
 
             // Check that it's the same image as usual.
             XCTAssertEqual(url, Self.dummyURL)
-            XCTAssertEqual(image.size.width, Self.sampleImage.size.width)
-            XCTAssertEqual(image.size.height, Self.sampleImage.size.height)
+            XCTAssertEqual(image.size.width, XXImage.sampleImage.size.width)
+            XCTAssertEqual(image.size.height, XXImage.sampleImage.size.height)
         }
         return inMemoryWriteExpectation
     }
@@ -169,7 +98,7 @@ final class CacheChainTests: XCTestCase {
         imageCache.localStorage.storeOverride = { data, fileName in
             localWriteExpectation.fulfill()
             XCTAssertEqual(fileName, Self.dummyURL.lastPathComponent)
-            XCTAssertEqual(data, Self.sampleImageData)
+            XCTAssertEqual(data, XXImage.sampleImageData)
         }
         return localWriteExpectation
     }
@@ -207,7 +136,7 @@ final class CacheChainTests: XCTestCase {
     // If the data is found locally, we return it and don't do anything else weird.
     func testLocallyStoredImageDataHappyPath() async throws {
         let imageCache = Self.buildImageCache()
-        let localReadExpectation = expectLocalRead(imageCache: imageCache, returning: Self.sampleImageData)
+        let localReadExpectation = expectLocalRead(imageCache: imageCache, returning: XXImage.sampleImageData)
 
         let inMemoryReadExpectation = expectNoInMemory(imageCache: imageCache)
 
@@ -219,15 +148,14 @@ final class CacheChainTests: XCTestCase {
 
         // Looping image -> data -> image -> data doesn't usually result in equal data or equal images as some config
         // data gets lost, but at least we can check pixel size.
-        XCTAssertEqual(image?.size.width, Self.sampleImage.size.width)
-        XCTAssertEqual(image?.size.height, Self.sampleImage.size.height)
+        XCTAssertEqual(image?.size, XXImage.sampleImage.size)
     }
 
     // If the data is not local, we get remote and store.
     func testRemotelyStoredImageDataHappyPath() async throws {
         let imageCache = Self.buildImageCache()
 
-        let networkReadExpectation = expectNetworkRead(imageCache: imageCache, returning: Self.sampleImageData)
+        let networkReadExpectation = expectNetworkRead(imageCache: imageCache, returning: XXImage.sampleImageData)
 
         let localReadExpectation = expectLocalRead(imageCache: imageCache)
 
@@ -249,8 +177,7 @@ final class CacheChainTests: XCTestCase {
 
         // Looping image -> data -> image -> data doesn't usually result in equal data or equal images as some config
         // data gets lost, but at least we can check pixel size.
-        XCTAssertEqual(image?.size.width, Self.sampleImage.size.width)
-        XCTAssertEqual(image?.size.height, Self.sampleImage.size.height)
+        XCTAssertEqual(image?.size, XXImage.sampleImage.size)
     }
 
     // If the local data is bad we recover by grabbing remote again.
@@ -311,7 +238,7 @@ final class CacheChainTests: XCTestCase {
             XCTAssertTrue(error is ImageConversionError)
         }
 
-        _ = expectNetworkRead(imageCache: imageCache, returning: Self.sampleImageData, existing: networkExpectation)
+        _ = expectNetworkRead(imageCache: imageCache, returning: XXImage.sampleImageData, existing: networkExpectation)
 
         let localWriteExpectation = expectLocalWrite(imageCache: imageCache)
 
@@ -332,8 +259,7 @@ final class CacheChainTests: XCTestCase {
 
         // Looping image -> data -> image -> data doesn't usually result in equal data or equal images as some config
         // data gets lost, but at least we can check pixel size.
-        XCTAssertEqual(image?.size.width, Self.sampleImage.size.width)
-        XCTAssertEqual(image?.size.height, Self.sampleImage.size.height)
+        XCTAssertEqual(image?.size, XXImage.sampleImage.size)
     }
 
     // Tests that retrying works if local data is corrupted and we inivalidate it.
@@ -373,7 +299,7 @@ final class CacheChainTests: XCTestCase {
 
         // XXXX
 
-        let networkExpectation = expectNetworkRead(imageCache: imageCache, returning: Self.sampleImageData)
+        let networkExpectation = expectNetworkRead(imageCache: imageCache, returning: XXImage.sampleImageData)
 
         let localGoodReadExpectation = expectLocalRead(imageCache: imageCache)
 
@@ -396,7 +322,6 @@ final class CacheChainTests: XCTestCase {
 
         // Looping image -> data -> image -> data doesn't usually result in equal data or equal images as some config
         // data gets lost, but at least we can check pixel size.
-        XCTAssertEqual(image?.size.width, Self.sampleImage.size.width)
-        XCTAssertEqual(image?.size.height, Self.sampleImage.size.height)
+        XCTAssertEqual(image?.size, XXImage.sampleImage.size)
     }
 }

--- a/Tests/SwiftCacheTests/XXImage.swift
+++ b/Tests/SwiftCacheTests/XXImage.swift
@@ -1,0 +1,83 @@
+//
+//  XXImage.swift
+//
+//
+//  Created by Óscar Morales Vivó on 1/28/24.
+//
+
+import Foundation
+
+#if os(macOS)
+// Shuts up the `Sendable` warnings in the tests.
+extension NSImage: @unchecked Sendable {}
+#endif
+
+#if os(macOS)
+typealias XXImage = NSImage
+
+extension XXImage {
+    static let sampleImage: NSImage = {
+        let imageSize = CGSize(width: 256.0, height: 256.0)
+        return NSImage(size: imageSize, flipped: false) { rect in
+            NSColor.yellow.setFill()
+            NSBezierPath.fill(rect)
+            NSColor.blue.setFill()
+            NSBezierPath(ovalIn: .init(
+                x: imageSize.width / 8.0,
+                y: imageSize.height / 8.0,
+                width: imageSize.width / 4.0,
+                height: imageSize.height / 4.0
+            )
+            ).fill()
+            NSBezierPath(ovalIn: .init(
+                x: (imageSize.width * 5.0) / 8.0,
+                y: (imageSize.height * 5.0) / 8.0,
+                width: imageSize.width / 4.0,
+                height: imageSize.height / 4.0
+            )
+            ).fill()
+
+            return true
+        }
+    }()
+
+    static let sampleImageData: Data = sampleImage.tiffRepresentation!
+}
+#else
+import UIKit
+
+typealias XXImage = UIImage
+
+extension XXImage {
+    static let sampleImage: UIImage = {
+        let imageSize = CGSize(width: 256.0, height: 256.0)
+        UIGraphicsBeginImageContext(imageSize)
+        defer {
+            UIGraphicsEndImageContext()
+        }
+
+        let context = UIGraphicsGetCurrentContext()!
+        UIColor.yellow.setFill()
+        context.fill(.init(origin: .zero, size: imageSize))
+        UIColor.blue.setFill()
+        UIBezierPath(ovalIn: .init(
+            x: imageSize.width / 8.0,
+            y: imageSize.height / 8.0,
+            width: imageSize.width / 4.0,
+            height: imageSize.height / 4.0
+        )
+        ).fill()
+        UIBezierPath(ovalIn: .init(
+            x: (imageSize.width * 5.0) / 8.0,
+            y: (imageSize.height * 5.0) / 8.0,
+            width: imageSize.width / 4.0,
+            height: imageSize.height / 4.0
+        )
+        ).fill()
+
+        return UIGraphicsGetImageFromCurrentImageContext()!
+    }()
+
+    static let sampleImageData: Data = sampleImage.pngData()!
+}
+#endif

--- a/Tests/SwiftCacheTests/XXImage.swift
+++ b/Tests/SwiftCacheTests/XXImage.swift
@@ -8,11 +8,11 @@
 import Foundation
 
 #if os(macOS)
+import Cocoa
+
 // Shuts up the `Sendable` warnings in the tests.
 extension NSImage: @unchecked Sendable {}
-#endif
 
-#if os(macOS)
 typealias XXImage = NSImage
 
 extension XXImage {


### PR DESCRIPTION
Update dependencies to use GlobalDependencies2 and a bit of cleanup.

Actual cleanup forthcoming, do not do a new release with these changes yet since it leaves behind several SDKs.